### PR TITLE
Save floor price to database (charts)

### DIFF
--- a/app/Jobs/CacheOrdinalsCollectionStats.php
+++ b/app/Jobs/CacheOrdinalsCollectionStats.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Models\FloorPrice;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Cache;
@@ -33,6 +34,11 @@ class CacheOrdinalsCollectionStats implements ShouldQueue
 
         if ($response->successful()) {
             Cache::put('ordinals_collection_stats_'.$this->symbol, $response->json());
+
+            $model = new FloorPrice;
+            $model->symbol = $response->json('symbol');
+            $model->price_in_sats = $response->json('floorPrice');
+            $model->save();
         }
     }
 }

--- a/app/Models/FloorPrice.php
+++ b/app/Models/FloorPrice.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FloorPrice extends Model
+{
+    const UPDATED_AT = null;
+}

--- a/database/migrations/2024_11_26_115953_create_floor_prices_table.php
+++ b/database/migrations/2024_11_26_115953_create_floor_prices_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('floor_prices', function (Blueprint $table) {
+            $table->id();
+            $table->string('symbol')->default('pizza-ninjas');
+            $table->double('price_in_sats')->unsigned();
+            $table->timestamp('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('floor_prices');
+    }
+};

--- a/tests/Unit/Jobs/CacheOrdinalsCollectionStatsTest.php
+++ b/tests/Unit/Jobs/CacheOrdinalsCollectionStatsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Jobs;
 
 use App\Jobs\CacheOrdinalsCollectionStats;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\Test;
@@ -10,6 +11,8 @@ use Tests\TestCase;
 
 class CacheOrdinalsCollectionStatsTest extends TestCase
 {
+    use RefreshDatabase;
+
     protected function validResponse(): array
     {
         return [


### PR DESCRIPTION
Start saving the floor price to db.
A follow up PR can add the chart to the homepage.